### PR TITLE
Iteration 3 df - winningest team and helper methods

### DIFF
--- a/lib/games_collection.rb
+++ b/lib/games_collection.rb
@@ -29,7 +29,7 @@ class GamesCollection
     end
     target_hash
   end
-  
+
   def highest_total_score
     @games.map {|game| game.away_goals.to_i + game.home_goals.to_i }.max
   end
@@ -79,7 +79,7 @@ class GamesCollection
   end
 
   # Iteration 2 required method
-  def average_goals_per_season
+  def average_goals_by_season
     every_unique("season", @games).reduce({}) do |hash, season|
       hash[season] = average_goals_in(all_games_in_season(season))
       hash

--- a/lib/games_teams_collection.rb
+++ b/lib/games_teams_collection.rb
@@ -78,15 +78,18 @@ class GamesTeamsCollection
   end
 
   # Helper method
+  def games_with_team(team_id)
+    find_by_in(team_id, "team_id", @games_teams)
+  end
+
+  # Helper method
   def total_games_with_team(team_id)
     total_found_by_in(team_id, "team_id", @games_teams)
   end
 
   # Helper method
   def total_wins_of_team(team_id)
-    find_by_in(team_id, "team_id", @games_teams).count do |game_team|
-      game_team.result == "WIN"
-    end
+    games_with_team(team_id).count { |game_team| game_team.result == "WIN" }
   end
 
   # Helper method designed to be reusable; consider moving to a stats module
@@ -97,5 +100,25 @@ class GamesTeamsCollection
   # Helper method
   def team_win_percentage(team_id)
     percent_of(total_wins_of_team(team_id), total_games_with_team(team_id))
+  end
+
+  # Helper method designed to be reusable; consider moving to a module
+  def every(attribute, collection)
+    collection.map { |element| element.send(attribute) }
+  end
+
+  # Helper method designed to be reusable; consider moving to a module
+  def every_unique(attribute, collection)
+    every(attribute, collection).uniq
+  end
+
+  # Helper method
+  def all_team_ids
+    every_unique("team_id", @games_teams)
+  end
+
+  # Core helper method for several Iteration 3 methods
+  def team_id_with_best_win_percentage
+    all_team_ids.max_by { |team_id| team_win_percentage(team_id) }
   end
 end

--- a/lib/games_teams_collection.rb
+++ b/lib/games_teams_collection.rb
@@ -67,21 +67,35 @@ class GamesTeamsCollection
     max_goals - min_goals
   end
 
-  def find_by(element, attribute)
-    @games_teams.find_all do |game_team|
-      game_team.send(attribute) == element
+  # Helper method designed to be reusable; consider moving to a parent Collection class
+  def find_by_in(element, attribute, collection)
+    collection.find_all { |member| member.send(attribute) == element }
+  end
+
+  # Helper method designed to be reusable; consider moving to a parent Collection class
+  def total_found_by_in(element, attribute, collection)
+    find_by_in(element, attribute, collection).length
+  end
+
+  # Helper method
+  def total_games_with_team(team_id)
+    total_found_by_in(team_id, "team_id", @games_teams)
+  end
+
+  # Helper method
+  def total_wins_of_team(team_id)
+    find_by_in(team_id, "team_id", @games_teams).count do |game_team|
+      game_team.result == "WIN"
     end
   end
 
-  def total_found_in(element, attribute)
-    find_by(element, attribute).length
+  # Helper method designed to be reusable; consider moving to a stats module
+  def percent_of(numerator, denominator)
+    ((numerator / denominator.to_f) * 100).round(2)
   end
 
-  def total_wins_of_team(team_id)
-    
-  end
-
+  # Helper method
   def team_win_percentage(team_id)
-
+    percent_of(total_wins_of_team(team_id), total_games_with_team(team_id))
   end
 end

--- a/lib/games_teams_collection.rb
+++ b/lib/games_teams_collection.rb
@@ -66,4 +66,22 @@ class GamesTeamsCollection
   def biggest_blowout
     max_goals - min_goals
   end
+
+  def find_by(element, attribute)
+    @games_teams.find_all do |game_team|
+      game_team.send(attribute) == element
+    end
+  end
+
+  def total_found_in(element, attribute)
+    find_by(element, attribute).length
+  end
+
+  def total_wins_of_team(team_id)
+    
+  end
+
+  def team_win_percentage(team_id)
+
+  end
 end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -46,4 +46,13 @@ class StatTracker
   def average_goals_by_season
     @games.average_goals_by_season
   end
+
+  def winningest_team
+  end
+
+  def best_fans
+  end
+
+  def worst_fans
+  end
 end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -47,7 +47,13 @@ class StatTracker
     @games.average_goals_by_season
   end
 
+  # Helper method
+  def name_of_team(team_id)
+    @teams.name_of_team_by_id(team_id)
+  end
+
   def winningest_team
+    name_of_team(@games_teams.team_id_with_best_win_percentage)
   end
 
   def best_fans

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -4,7 +4,7 @@ class StatTracker
   def initialize(file_paths)
     @games = GamesCollection.new(file_paths[:games])
     @teams = TeamsCollection.new(file_paths[:teams])
-    @games_teams = GamesTeamsCollection.new(file_paths[:games_teams])
+    @games_teams = GamesTeamsCollection.new(file_paths[:game_teams])
   end
 
   def self.from_csv(file_paths)

--- a/lib/team.rb
+++ b/lib/team.rb
@@ -4,8 +4,8 @@ class Team
 
   def initialize(team_info)
     @team_id = team_info[:team_id]
-    @franchise_id = team_info[:franchise_id]
-    @team_name = team_info[:team_name]
+    @franchise_id = team_info[:franchiseid]
+    @team_name = team_info[:teamname]
     @abbreviation = team_info[:abbreviation]
     @stadium = team_info[:stadium]
     @link = team_info[:link]

--- a/lib/teams_collection.rb
+++ b/lib/teams_collection.rb
@@ -12,4 +12,8 @@ class TeamsCollection
     end
     objects
   end
+
+  def name_of_team_by_id(team_id)
+    @teams.find {|team| team.team_id == team_id}.team_name
+  end
 end

--- a/runner.rb
+++ b/runner.rb
@@ -3,10 +3,10 @@ require_relative './lib/stat_tracker'
 
 # Using dummy data files for now, change later
 
-locations = {
+file_paths = {
   games: './data/dummy_games.csv',
   teams: './data/dummy_teams.csv',
-  games_teams: './data/dummy_games_teams.csv'
+  game_teams: './data/dummy_games_teams.csv'
 }
 
 stat_tracker = StatTracker.from_csv(locations)

--- a/test/games_collection_test.rb
+++ b/test/games_collection_test.rb
@@ -51,7 +51,7 @@ class GamesCollectionTest < Minitest::Test
 
     assert_equal expected, @games_collection.count_of_games_by_season
   end
-  
+
   def test_it_grabs_highest_total_score
     assert_equal 7, @games_collection.highest_total_score
   end
@@ -59,7 +59,7 @@ class GamesCollectionTest < Minitest::Test
   def test_it_grabs_lowest_total_score
     assert_equal 1, @games_collection.lowest_total_score
   end
-  
+
   def test_it_can_return_total_goals_across_all_games
     assert_equal 387, @games_collection.total_goals(@games_collection.games)
   end
@@ -96,7 +96,7 @@ class GamesCollectionTest < Minitest::Test
     assert_equal 16, @games_collection.all_games_in_season("20142015").length
   end
 
-  def test_it_can_return_hash_of_average_goals_per_season
+  def test_it_can_return_hash_of_average_goals_by_season
     expected_hash = {
                       "20122013"=>3.86,
                       "20162017"=>4.75,
@@ -104,6 +104,6 @@ class GamesCollectionTest < Minitest::Test
                       "20152016"=>3.88,
                       "20132014"=>4.33
                     }
-    assert_equal expected_hash, @games_collection.average_goals_per_season
+    assert_equal expected_hash, @games_collection.average_goals_by_season
   end
 end

--- a/test/games_teams_collection_test.rb
+++ b/test/games_teams_collection_test.rb
@@ -65,6 +65,12 @@ class GamesTeamsCollectionTest < Minitest::Test
     assert_equal true, @games_teams_collection.find_by_in("6", "team_id", @games_teams_collection.games_teams).all? { |element| element.is_a?(GameTeam) }
   end
 
+  def test_it_can_find_all_rows_with_given_team_id
+    assert_instance_of Array, @games_teams_collection.games_with_team("6")
+    assert_equal 9, @games_teams_collection.games_with_team("6").length
+    assert_equal true, @games_teams_collection.games_with_team("6").all? { |element| element.is_a?(GameTeam) }
+  end
+
   def test_it_totals_games_for_given_team
     assert_equal 9, @games_teams_collection.total_found_by_in("6", "team_id", @games_teams_collection.games_teams)
     assert_equal 6, @games_teams_collection.total_found_by_in("2", "team_id", @games_teams_collection.games_teams)
@@ -83,5 +89,14 @@ class GamesTeamsCollectionTest < Minitest::Test
   def test_it_calculates_win_percentage_for_given_team_id
     assert_equal 100.00, @games_teams_collection.team_win_percentage("6")
     assert_equal 33.33, @games_teams_collection.team_win_percentage("2")
+  end
+
+  def test_it_can_find_all_team_ids
+    expected_array = ["2", "3", "5", "6", "8", "9", "15", "16", "17", "19", "24", "26", "30"].sort
+    assert_equal expected_array, @games_teams_collection.all_team_ids.sort
+  end
+
+  def test_it_can_return_team_id_of_team_with_best_win_percentage
+    assert_equal "6", @games_teams_collection.team_id_with_best_win_percentage
   end
 end

--- a/test/games_teams_collection_test.rb
+++ b/test/games_teams_collection_test.rb
@@ -58,4 +58,24 @@ class GamesTeamsCollectionTest < Minitest::Test
   def test_it_calculates_percentage_ties
     assert_equal 2.02, @games_teams_collection.percentage_ties
   end
+
+  def test_it_can_find_rows_by_given_value_in_given_column
+    assert_instance_of Array, @games_teams_collection.find_by("6", "team_id")
+    assert_equal 9, @games_teams_collection.find_by("6", "team_id").length
+    assert_equal true, @games_teams_collection.find_by("6", "team_id").all? { |element| element.is_a?(GameTeam) }
+  end
+
+  def test_it_totals_games_for_given_team
+    assert_equal 9, @games_teams_collection.total_found_in("6", "team_id")
+  end
+
+  def test_it_totals_wins_of_given_team
+    assert_equal 9, @games_teams_collection.total_wins_of_team("6")
+    assert_equal 2, @games_teams_collection.total_wins_of_team("2")
+  end
+
+  def test_it_calculates_win_percentage_for_given_team_id
+    skip
+    assert_equal 75.34, @games_teams_collection.team_win_percentage("6")
+  end
 end

--- a/test/games_teams_collection_test.rb
+++ b/test/games_teams_collection_test.rb
@@ -60,13 +60,14 @@ class GamesTeamsCollectionTest < Minitest::Test
   end
 
   def test_it_can_find_rows_by_given_value_in_given_column
-    assert_instance_of Array, @games_teams_collection.find_by("6", "team_id")
-    assert_equal 9, @games_teams_collection.find_by("6", "team_id").length
-    assert_equal true, @games_teams_collection.find_by("6", "team_id").all? { |element| element.is_a?(GameTeam) }
+    assert_instance_of Array, @games_teams_collection.find_by_in("6", "team_id", @games_teams_collection.games_teams)
+    assert_equal 9, @games_teams_collection.find_by_in("6", "team_id", @games_teams_collection.games_teams).length
+    assert_equal true, @games_teams_collection.find_by_in("6", "team_id", @games_teams_collection.games_teams).all? { |element| element.is_a?(GameTeam) }
   end
 
   def test_it_totals_games_for_given_team
-    assert_equal 9, @games_teams_collection.total_found_in("6", "team_id")
+    assert_equal 9, @games_teams_collection.total_found_by_in("6", "team_id", @games_teams_collection.games_teams)
+    assert_equal 6, @games_teams_collection.total_found_by_in("2", "team_id", @games_teams_collection.games_teams)
   end
 
   def test_it_totals_wins_of_given_team
@@ -74,8 +75,13 @@ class GamesTeamsCollectionTest < Minitest::Test
     assert_equal 2, @games_teams_collection.total_wins_of_team("2")
   end
 
+  def test_it_can_make_percentage_with_numerator_and_denominator
+    assert_equal 50.00, @games_teams_collection.percent_of(1, 2)
+    assert_equal 33.33, @games_teams_collection.percent_of(2, 6)
+  end
+
   def test_it_calculates_win_percentage_for_given_team_id
-    skip
-    assert_equal 75.34, @games_teams_collection.team_win_percentage("6")
+    assert_equal 100.00, @games_teams_collection.team_win_percentage("6")
+    assert_equal 33.33, @games_teams_collection.team_win_percentage("2")
   end
 end

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -24,27 +24,27 @@ class StatTrackerTest < Minitest::Test
   # Begin tests for iteration-required methods
 
   def test_it_grabs_highest_total_score
-    assert_equal 7, @stat_tracker.games.highest_total_score
+    assert_equal 7, @stat_tracker.highest_total_score
   end
 
   def test_it_grabs_lowest_total_score
-    assert_equal 1, @stat_tracker.games.lowest_total_score
+    assert_equal 1, @stat_tracker.lowest_total_score
   end
 
   def test_it_has_a_big_blow_out
-    assert_equal 4, @stat_tracker.games_teams.biggest_blowout
+    assert_equal 4, @stat_tracker.biggest_blowout
   end
 
   def test_it_calculates_home_win_percentage_to_the_hundredths
-    assert_equal 65.31, @stat_tracker.games_teams.percentage_home_wins
+    assert_equal 65.31, @stat_tracker.percentage_home_wins
   end
 
   def test_it_calculates_away_win_percentage_to_the_hundredths
-    assert_equal 32.0, @stat_tracker.games_teams.percentage_visitor_wins
+    assert_equal 32.0, @stat_tracker.percentage_visitor_wins
   end
 
   def test_it_calculates_percentage_ties
-    assert_equal 2.02, @stat_tracker.games_teams.percentage_ties
+    assert_equal 2.02, @stat_tracker.percentage_ties
   end
 
   def test_it_can_count_game_by_season
@@ -57,14 +57,14 @@ class StatTrackerTest < Minitest::Test
       "20132014" => 6
     }
 
-    assert_equal expected, @stat_tracker.games.count_of_games_by_season
+    assert_equal expected, @stat_tracker.count_of_games_by_season
   end
 
   def test_it_can_calculate_average_goals_per_game
-    assert_equal 3.91, @stat_tracker.games.average_goals_per_game
+    assert_equal 3.91, @stat_tracker.average_goals_per_game
   end
 
-  def test_it_can_return_hash_of_average_goals_per_season
+  def test_it_can_return_hash_of_average_goals_by_season
     expected_hash = {
                       "20122013"=>3.86,
                       "20162017"=>4.75,
@@ -72,7 +72,7 @@ class StatTrackerTest < Minitest::Test
                       "20152016"=>3.88,
                       "20132014"=>4.33
                     }
-    assert_equal expected_hash, @stat_tracker.games.average_goals_per_season
+    assert_equal expected_hash, @stat_tracker.average_goals_by_season
   end
 
   def test_it_can_get_name_of_team_by_id

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -6,7 +6,7 @@ class StatTrackerTest < Minitest::Test
     file_paths = {
                   games: './data/dummy_games.csv',
                   teams: './data/dummy_teams.csv',
-                  games_teams: './data/dummy_games_teams.csv'
+                  game_teams: './data/dummy_games_teams.csv'
                 }
     @stat_tracker = StatTracker.from_csv(file_paths)
   end

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -74,4 +74,19 @@ class StatTrackerTest < Minitest::Test
                     }
     assert_equal expected_hash, @stat_tracker.games.average_goals_per_season
   end
+
+  # Name of the team with the highest win percentage across all seasons.
+  def test_it_can_find_winningest_team
+    assert_equal "Houston Dynamo", @stat_tracker.winningest_team
+  end
+
+  # Name of the team with biggest difference between home and away win percentages.
+  def test_it_can_find_team_with_best_fans
+    assert_equal "New England Revolution", @stat_tracker.best_fans
+  end
+
+  # List of names of all teams with better away records than home records.
+  def test_it_can_find_team_with_worst_fans
+    assert_equal "Philadelphia Union", @stat_tracker.worst_fans
+  end
 end

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -75,18 +75,24 @@ class StatTrackerTest < Minitest::Test
     assert_equal expected_hash, @stat_tracker.games.average_goals_per_season
   end
 
-  # Name of the team with the highest win percentage across all seasons.
-  def test_it_can_find_winningest_team
-    assert_equal "Houston Dynamo", @stat_tracker.winningest_team
+  def test_it_can_get_name_of_team_by_id
+    assert_equal "FC Dallas", @stat_tracker.name_of_team("6")
+    assert_equal "Los Angeles FC", @stat_tracker.name_of_team("28")
+  end
+
+  def test_it_can_find_name_of_winningest_team
+    assert_equal "FC Dallas", @stat_tracker.winningest_team
   end
 
   # Name of the team with biggest difference between home and away win percentages.
   def test_it_can_find_team_with_best_fans
+    skip
     assert_equal "New England Revolution", @stat_tracker.best_fans
   end
 
   # List of names of all teams with better away records than home records.
   def test_it_can_find_team_with_worst_fans
+    skip
     assert_equal "Philadelphia Union", @stat_tracker.worst_fans
   end
 end

--- a/test/team_test.rb
+++ b/test/team_test.rb
@@ -5,8 +5,8 @@ class TeamTest < Minitest::Test
   def setup
     team_hash = {
                   team_id: 1,
-                  franchise_id: 23,
-                  team_name: "Atlanta United",
+                  franchiseid: 23,
+                  teamname: "Atlanta United",
                   abbreviation: "ATL",
                   stadium: "Mercedes-Benz Stadium",
                   link: "/api/v1/teams/1"

--- a/test/teams_collection_test.rb
+++ b/test/teams_collection_test.rb
@@ -14,4 +14,9 @@ class TeamsCollectionTest < Minitest::Test
     assert_equal 32, @teams_collection.teams.length
     assert_equal true, @teams_collection.teams.all? {|team| team.is_a?(Team)}
   end
+
+  def test_it_can_get_name_of_team_by_id
+    assert_equal "FC Dallas", @teams_collection.name_of_team_by_id("6")
+    assert_equal "Los Angeles FC", @teams_collection.name_of_team_by_id("28")
+  end
 end


### PR DESCRIPTION
@philjdelong @itemniner @sasloan 

Here are my changes to get the `winningest_team` method working, and laying the groundwork for the `best_fans` and `worst_fans` methods. I also created a helper method that will probably come in handy for many of the other Iteration 3 methods, `team_name_by_id`, which lives on TeamsCollection but has a wrapper method on StatTracker so you can invoke it from there. 

I also corrected a small typo in Teams and TeamsTest that was keeping the team_name attribute from populating from the CSV files, without which you can't get the team names (the column name doesn't have an underscore but Teams was looking for a :team_names symbol). 